### PR TITLE
Fix for crash caused by incorrect mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# gradle
+
+.gradle/
+build/
+out/
+classes/
+
+# eclipse
+
+*.launch
+
+# idea
+
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# vscode
+
+.settings/
+.vscode/
+bin/
+.classpath
+.project
+
+# macos
+
+*.DS_Store
+
+# fabric
+
+run/
+
+# java
+
+hs_err_*.log
+replay_*.log
+*.hprof
+*.jfr

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,8 @@ org.gradle.parallel=true
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 minecraft_version=1.21
-yarn_mappings=1.21+build.8
-loader_version=0.15.11
+yarn_mappings=1.21+build.9
+loader_version=0.16.9
 
 # Mod Properties
 mod_version=1.0.1
@@ -14,4 +14,4 @@ maven_group=com.github.korjeek
 archives_base_name=copperbeaconsmod
 
 # Dependencies
-fabric_version=0.100.6+1.21
+fabric_version=0.102.0+1.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21+build.8
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.0.0
+mod_version=1.0.1
 maven_group=com.github.korjeek
 archives_base_name=copperbeaconsmod
 

--- a/src/main/java/net/korjeek/copperbeaconsmod/mixin/BeaconScreenMixin.java
+++ b/src/main/java/net/korjeek/copperbeaconsmod/mixin/BeaconScreenMixin.java
@@ -4,50 +4,43 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.BeaconScreen;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(BeaconScreen.class)
 public abstract class BeaconScreenMixin extends HandledScreenMixin {
 
-	@Unique
-	private static final Identifier TEXTURE = Identifier.ofVanilla("textures/gui/container/beacon.png");
+  @ModifyArg(method = "drawBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawItem(Lnet/minecraft/item/ItemStack;II)V"), index = 1)
+  private int modifyXPositions(int x) {
+    // Get the base x position from the original x coordinate
+    int i = (this.width - this.backgroundWidth) / 2;
 
-	/**
-	 * @author korjeek
-	 * @reason Because the changes affect important aspects of the original method
-	 */
-	@Overwrite
-	public void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
-		int i = (this.width - this.backgroundWidth) / 2;
-		int j = (this.height - this.backgroundHeight) / 2;
-		context.drawTexture(TEXTURE, i, j, 0, 0, this.backgroundWidth, this.backgroundHeight);
-		context.getMatrices().push();
-		context.getMatrices().translate(0.0F, 0.0F, 100.0F);
-		context.drawItem(new ItemStack(Items.NETHERITE_INGOT), i + 13, j + 109);
-		context.drawItem(new ItemStack(Items.EMERALD), i + 34, j + 109);
-		context.drawItem(new ItemStack(Items.DIAMOND), i + 34 + 22, j + 109);
-		context.drawItem(new ItemStack(Items.GOLD_INGOT), i + 35 + 44, j + 109);
-		context.drawItem(new ItemStack(Items.IRON_INGOT), i + 35 + 66, j + 109);
-		context.drawItem(new ItemStack(Items.COPPER_INGOT), i + 35 + 88, j + 109);
-		context.getMatrices().pop();
-	}
+    // Determine where to move each item's sprite based on the original x position
+    if (x == i + 20) return i + 13;      // Netherite Ingot
+    if (x == i + 41) return i + 34;      // Emerald Ingot
+    if (x == i + 41 + 22) return i + 34 + 22;  // Diamond
+    if (x == i + 42 + 44) return i + 35 + 44;  // Gold Ingot
+    if (x == i + 42 + 66) return i + 35 + 66;  // Iron Ingot
+    return x;
+  }
 
-	@ModifyArg(method = "init", at = @At(value = "INVOKE",
-			target = "Lnet/minecraft/client/gui/screen/ingame/BeaconScreen$DoneButtonWidget;<init>(Lnet/minecraft/client/gui/screen/ingame/BeaconScreen;II)V"),
-			index = 1)
-	public int changeDoneButtonPos(int x){
-		return x + 5;
-	}
+  @Inject(method = "drawBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawItem(Lnet/minecraft/item/ItemStack;II)V", shift = At.Shift.AFTER))
+  private void addCopperIngot(DrawContext context, float delta, int mouseX, int mouseY, CallbackInfo ci) {
+    int i = (this.width - this.backgroundWidth) / 2;
+    int j = (this.height - this.backgroundHeight) / 2;
+    context.drawItem(new ItemStack(Items.COPPER_INGOT), i + 35 + 88, j + 109);
+  }
 
-	@ModifyArg(method = "init", at = @At(value = "INVOKE",
-			target = "Lnet/minecraft/client/gui/screen/ingame/BeaconScreen$CancelButtonWidget;<init>(Lnet/minecraft/client/gui/screen/ingame/BeaconScreen;II)V"),
-			index = 1)
-	public int changeCancelButtonPos(int x){
-		return x + 5;
-	}
+  @ModifyArg(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BeaconScreen$DoneButtonWidget;<init>(Lnet/minecraft/client/gui/screen/ingame/BeaconScreen;II)V"), index = 1)
+  public int changeDoneButtonPos(int x) {
+    return x + 5;
+  }
+
+  @ModifyArg(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/BeaconScreen$CancelButtonWidget;<init>(Lnet/minecraft/client/gui/screen/ingame/BeaconScreen;II)V"), index = 1)
+  public int changeCancelButtonPos(int x) {
+    return x + 5;
+  }
 }


### PR DESCRIPTION
### This PR fixes the possibility of any crash with other mods that mixin to `BeaconScreen`.
In the current implementation, `BeaconScreen#drawBackground` is overwritten, which causes any other mod mixing in to this method to fail, and Minecraft will crash.

I've adapted your code using `@ModifyArg` to change the position of vanilla's ingot sprites, and `@Inject` to add the copper ingot.

This PR also includes a boilerplate .gitignore, a mod version bump and the newest recommended fabric dependency versions @korjeek.